### PR TITLE
Add ShowGeneratedCashValue query parameter

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,6 +37,8 @@ You can append additional query-string parameters to show more advanced informat
 - `ShowAdvancedInfo=true` - show or hide the advanced information panel for each inverter - when shown, includes solar power per inverter and 
   individual battery state of charge.
   Defaults to `true` (shows the advanced info panel).
+- `ShowGeneratedCashValue=true` - show or hide the cash value shown next to `Generated`.
+  Defaults to `true` (shows the generated cash value).
 - `ShowTime=true` - show or hide the current time in the top-left corner of the app - useful if you want to use this app fullscreen
   on a tablet or mobile device.
   Defaults to `false` (hides the time).
@@ -53,7 +55,7 @@ You can append additional query-string parameters to show more advanced informat
 For example, you can append query-string parameters like this:
 
 ```
-http://homeassistant.local:3000?ShowTime=true&LightMode=true
+http://homeassistant.local:3000?ShowTime=true&LightMode=true&ShowGeneratedCashValue=false
 ```
 
 ## Adding to a Home Assistant Dashboard

--- a/js/app.js
+++ b/js/app.js
@@ -45,6 +45,9 @@ class App {
         me.showAdvancedInfo = urlParams.has('ShowAdvancedInfo')
             ? urlParams.get('ShowAdvancedInfo') === 'true'
             : true;
+        me.showGeneratedCashValue = urlParams.has('ShowGeneratedCashValue')
+            ? urlParams.get('ShowGeneratedCashValue') === 'true'
+            : true;
         me.showTime = urlParams.get('ShowTime') === 'true';
         me.debugMode = urlParams.get('DebugMode') === 'true';
         me.lightMode = urlParams.get('LightMode') === 'true';
@@ -63,6 +66,13 @@ class App {
             document.getElementById('summary_row_peak_import').setAttribute('transform', 'translate(0, -41)');
             document.getElementById('summary_row_offpeak_import').setAttribute('transform', 'translate(0, -28)');
             document.getElementById('summary_row_grid_export').setAttribute('transform', 'translate(0, -14)');
+        }
+
+        if (!me.showGeneratedCashValue) {
+            const generatedIncomeEl = document.getElementById('solar_generated_income_text');
+            if (generatedIncomeEl) {
+                generatedIncomeEl.setAttribute('display', 'none');
+            }
         }
 
         // If the hostname has been overridden, use it
@@ -607,6 +617,10 @@ class App {
 
         // Second pass: derive any computed sensor values, then render each sensor
         InverterSensors.forEach((sensor) => {
+            if (!me.showGeneratedCashValue && sensor.id === 'Solar_Income') {
+                return;
+            }
+
             let value = me.deriveSensorValue(sensor, me.processedInverterData[sensor.id]);
 
             if (value || sensor.forceRefresh) {


### PR DESCRIPTION
This adds a new dashboard runtime query-string parameter:

- `ShowGeneratedCashValue=true`

Behaviour:
- defaults to `true`
- when set to `false`, hides the cash value shown next to `Generated`

Implementation details:
- parse the new query-string parameter in `js/app.js`
- when disabled:
  - hide the SVG text element for generated cash value
  - skip processing the `Solar_Income` summary sensor
- updated `ReadMe.md` to document the new parameter and example usage

Example:
- `http://host:3000/?ShowGeneratedCashValue=false`

This change is presentation-only. It does not alter the generated energy value itself or any underlying calculations.

NOTE: You might want to test this in an Incognito/Private window to avoid cache issues preventing the new query-parameter from working when set to `false`